### PR TITLE
Docs edits

### DIFF
--- a/content/blog/2016-01-04/index.md
+++ b/content/blog/2016-01-04/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout-blog-post
 author: Blackbaud-PaulCrowder
-name: Welcome to the <%= stache.config.product_name_short %> Blog
+name: Welcome to the <%= stache.config.product_name_short %> blog
 pubDate: Monday, January 4, 2016
 ---
 

--- a/content/blog/2016-01-06/index.md
+++ b/content/blog/2016-01-06/index.md
@@ -1,7 +1,7 @@
 ---
 layout: layout-blog-post
 author: Blackbaud-PaulCrowder
-name: Sky UX CDN Fallback Strategy
+name: Sky UX CDN fallback strategy
 pubDate: Wednesday, January 6, 2016
 markdown: true
 ---
@@ -20,7 +20,7 @@ Once you've downloaded Fallback JS you can include it on your page.  For simplic
 
 `<script src="/bower_components/fallback/fallback.min.js"></script>`
 
-##Importing the Sky UX Library
+##Importing the Sky UX library
 
 Now that you've added the Fallback JS library it's time to add Sky UX to your page.  You'll need to download and host Sky UX on the same server where Fallback JS and your web application are hosted.  This is where Fallback JS will load Sky UX from in the case the CDN is unavailable.
 
@@ -66,11 +66,11 @@ The two CSS resources that are loaded are the Sky UX CSS file (aliased as `sky_c
 
 In addition to the two CSS resources, we're also loading two JavaScript files: Sky UX's JS file and your web application's CSS file.  Unlike the CSS resources that are aliased using arbitrary names, each JavaScript alias must be an object that the JavaScript file adds to the global `window` object.  Since the Sky UX bundle also loads AngularJS, and since AngularJS adds an `angular` object to `window`, we'll use `angular` as the alias.  For the application's JS I've just added the line `window.MYAPP_READY = true;` to the bottom of my application's JS code so I can reference it here.
 
-###Specifying Load Order
+###Specifying load order
 
 The second parameter passed to `fallback.load()` consists of a `shim` property which you can use to define the load order of the JavaScript and CSS files.  Each property on the `shim` object is named after the corresponding resource's alias and is set to an array of other resources that must be loaded before that resource is loaded.  In our example we've stated that our own app's JS and CSS depend on Sky UX's JS and CSS, ensuring Sky UX loads before our app's resources load.
 
-##Dealing With CDN Failures
+##Dealing with CDN failures
 
 The option parameter's `callback` property can be used to specify a function that is called after all resources have been loaded.  This callback accepts `success` and `failed` parameters, the latter of which can be used to determine which requests failed.  Even though the fallback functionality should keep your app working properly when the CDN fails to load, you might want to know about failures so that you can include them in any instrumentation you are keeping for your application.
 

--- a/content/blog/2016-02-19/index.md
+++ b/content/blog/2016-02-19/index.md
@@ -24,7 +24,7 @@ This allows for uploading and displaying an image to identify a record.
 ### [Error](http://skyux.developer.blackbaud.com/components/error/)
 We created a standard layout and styling for error messaging. Now that this core piece is in place we can create a set of standard content for common error types. 
 
-### [Date range picker](http://skyux.developer.blackbaud.com/components/daterangepicker/)
+### [Date-range picker](http://skyux.developer.blackbaud.com/components/daterangepicker/)
 We extended this control to allow a “Specific date range” option in cases where the predefined date ranges are insufficient. 
 
 ### Accessibility

--- a/content/core-design/index.html
+++ b/content/core-design/index.html
@@ -1,6 +1,6 @@
 ---
 layout: layout-panels
-name: "Core Design"
+name: Core design
 order: 5
 ---
 

--- a/content/core-design/typography/index.html
+++ b/content/core-design/typography/index.html
@@ -42,7 +42,7 @@ items:
   - name: Field label
     usage: This class formats labels for read-only fields that do not accept input. It uses a muted color because the label that identifies the field is less important than the content.
     code: <div class="bb-field-label">Field label</div>
-    styling: 'Open Sans Regular 13px #7073741'
+    styling: 'Open Sans Regular 13px #707374'
 
   - name: Form input label
     usage: This class formats labels for input fields. It is darker than labels for read-only fields to help the text stand out they alongside visually heavier input controls.

--- a/content/getting-started/create-a-record-page/index.html
+++ b/content/getting-started/create-a-record-page/index.html
@@ -1,7 +1,7 @@
 ---
 layout: layout-sidebar
 order: 12
-name: Create a Record Page
+name: Create a record page
 ---
 
 <h1>{{ name }}</h1>
@@ -11,7 +11,7 @@ name: Create a Record Page
 
 <p>Record pages usually display information about specific records in two distinct sections: a summary section and a tiles section.</p>
 
-<h2>Summary Section</h2>
+<h2>Summary section</h2>
 
 <p>The summary section resides at the top of the page to provide a general overview of a record. For example, it can display information such as a record name, description, and profile picture. To add a summary section to your page, use the <a href="../../components/pagesummary">page summary directive</a>. Here's an example of a summary section with a name, description, and profile photo:</p>
 
@@ -21,7 +21,7 @@ name: Create a Record Page
 
 <pre><code class="language-markup">{{ include "includes/create-a-record-page/summary-section.html" escape=true }}</code></pre>
 
-<h2>Tiles Section</h2>
+<h2>Tiles section</h2>
 
 <p>The tiles section usually consists of two columns of tiles (or one column for extra-small screen sizes like mobile phones) that displays more information about a record in logical sections. Each tile includes a header and body for the tile's title and content. Tiles are collapsible, and if they are used in conjunction with a <a href="../../components/tiles">tiles dashboard</a>, users can rearrange them.</p>
 
@@ -36,5 +36,5 @@ name: Create a Record Page
 <p>Tiles can display data in all kinds of formats, including a list of fields with their values, a repeater view of records, a chart, or anything else you can imagine. You can find more information about common data elements in tiles in the <a href="../../components">Components</a> section, but for now let's move on to tabbed pages.</p>
 
 <hr>
-<p><strong>Next Step:</strong> <a href="../create-a-tabbed-page">Create a Tabbed Page &raquo;</a></p>
+<p><strong>Next step:</strong> <a href="../create-a-tabbed-page">Create a tabbed page &raquo;</a></p>
 </div>

--- a/content/getting-started/create-a-tabbed-page/index.html
+++ b/content/getting-started/create-a-tabbed-page/index.html
@@ -1,7 +1,7 @@
 ---
 layout: layout-sidebar
 order: 13
-name: Create a Tabbed Page
+name: Create a tabbed page
 files:
   js:
     - /assets/js/tabbedpage.js
@@ -11,7 +11,7 @@ files:
 
 <p>Now that we know how to <a href="../create-a-record-page/">create a record page</a>, lets look at how to create the other common page type in {{ stache.config.product_name_short }}: a tabbed page. While record pages display data for individual records, tabbed pages usually serve as overviews for multiple records. For example, tabbed pages can display lists of constituents or gifts.</p>
 
-<h2>Tabs Component</h2>
+<h2>Tabs component</h2>
 
 <p>{{ stache.config.product_name_short }} uses the <a href="https://angular-ui.github.io/bootstrap/" target="blank">UI Bootstrap</a> Tabs module to display tabs. It adds {{ stache.config.product_name_short }}-specific functionality with its <a href="../../components/tabset/">tabset module</a>.</p>
 
@@ -30,6 +30,6 @@ files:
 <hr>
 
 <p>
-  <strong>Next Step:</strong> <a href="../next-steps/">Build Out Your Application &raquo;</a>
+  <strong>Next step:</strong> <a href="../next-steps/">Build out your application &raquo;</a>
 </p>
 </div>

--- a/content/getting-started/index.html
+++ b/content/getting-started/index.html
@@ -1,7 +1,7 @@
 ---
 layout: layout-sidebar
 order: 2
-name: "Getting Started"
+name: Getting started
 showNavDropdown: false
 ---
 
@@ -19,10 +19,10 @@ In addition to these tutorials, the  website also includes reference material fo
 
 <hr>
 
-<p><strong>Next Steps:</strong></p>
+<p><strong>Next steps:</strong></p>
 <ul>
-<li><a href="../getting-started/start-a-project">Start a Project &raquo;</a></li>
-<li><a href="../getting-started/create-a-record-page">Create a Record Page &raquo;</a></li>
-<li><a href="../getting-started/create-a-tabbed-page">Create a Tabbed Page &raquo;</a></li>
-<li><a href="../getting-started/next-steps">Build Out Your Application &raquo;</a></li>
+<li><a href="../getting-started/start-a-project">Start a project &raquo;</a></li>
+<li><a href="../getting-started/create-a-record-page">Create a record Page &raquo;</a></li>
+<li><a href="../getting-started/create-a-tabbed-page">Create a tabbed Page &raquo;</a></li>
+<li><a href="../getting-started/next-steps">Build out your application &raquo;</a></li>
 </ul>

--- a/content/getting-started/next-steps/index.html
+++ b/content/getting-started/next-steps/index.html
@@ -15,7 +15,7 @@ name: Build out your application
 <p>In addition to the Getting started tutorials, the website features reference materials for {{ stache.config.product_name_short }}'s HTML, CSS, and JavaScript framework. We continue to expand the documentation to provide additional guidance and to improve existing documentation for components, design patterns, and layout elements.</p>
 
 <ul>
-    <li>The <a href="../../components">Components section</a> describes engineering tools such as directives and services that developers can implement to create the user experience patterns.</li>
+    <li>The <a href="../../components">Components section</a> describes tools such as directives and services that developers can implement to create the user experience patterns.</li>
     <li>The <a href="../../guidelines">Guidelines section</a> provides guidance on the optimal way to apply {{ stache.config.product_name_short }} components and the context for when to use them.</li>
     <li>The <a href="../../core-design">Core design section</a> describes the core  elements that act as building blocks for components and implement {{ stache.config.product_name_short }} styles and patterns.</li>
 </ul>

--- a/content/getting-started/next-steps/index.html
+++ b/content/getting-started/next-steps/index.html
@@ -1,44 +1,42 @@
 ---
 layout: layout-sidebar
 order: 14
-name: Build Out Your Application
+name: Build out your application
 ---
 
 <h1>{{ name }}</h1>
 
-<p>After the Getting Started tutorials, you are ready to create your own {{ stache.config.product_name_short }} applications. For more information about the toolset to create applications, see to the {{ stache.config.product_name_short }} reference materials.</p>
+<p>After the Getting started tutorials, you are ready to create your own {{ stache.config.product_name_short }} applications. For more information about the toolset to create applications, see to the {{ stache.config.product_name_short }} reference materials.</p>
 
 <p class="alert alert-info">The current tutorials only cover the basics to get you started, but we will create additional tutorials as we identify areas where they are necessary.</p>
 
-<h2>Reference Materials</h2>
+<h2>Reference materials</h2>
 
-<p>In addition to the Getting Started tutorials, the website features reference materials for {{ stache.config.product_name_short }}'s HTML, CSS, and JavaScript framework. Currently, the <a href="../../components">Components</a> section describes engineering tools such as directives and services and provides examples and code samples.</p>
-
-<p>We are currently expanding the Components section into a References section that will also describe {{ stache.config.product_name_short }} design patterns and layout elements to provide additional guidance.</p>
+<p>In addition to the Getting started tutorials, the website features reference materials for {{ stache.config.product_name_short }}'s HTML, CSS, and JavaScript framework. We continue to expand the documentation to provide additional guidance and to improve existing documentation for components, design patterns, and layout elements.</p>
 
 <ul>
-<li>The Layout section will describe layout elements to build your application such as cards, forms, pages, headers, repeaters, summaries, tabs, and tiles.</li>
-<li>The Patterns section will describe the design patterns that create a consisstent user experience. Patterns are key concepts behind {{ stache.config.product_name_short }}'s design philosophy and provide guidance for design decisions and interaction patterns such as how to add, edit, and remove data; error handling; how to display, highlight, and select data; alerts and notifications; navigation; how to search and filter data; styling; and user assistance.</li>
+    <li>The <a href="../../components">Components section</a> describes engineering tools such as directives and services that developers can implement to create the user experience patterns.</li>
+    <li>The <a href="../../guidelines">Guidelines section</a> provides guidance on the optimal way to apply {{ stache.config.product_name_short }} components and the context for when to use them.</li>
+    <li>The <a href="../../core-design">Core design section</a> describes the core  elements that act as building blocks for components and implement {{ stache.config.product_name_short }} styles and patterns.</li>
+</ul>
+<hr>
+
+<p><strong>Next steps:</strong></p>
+<ul>
+<li><a href="../../components">Components</a></li>
+<li><a href="../../guidelines">Guidelines</a></li>
+<li><a href="../../core-design">Core design</a></li>
+</ul>
+
+<hr>
+
 <!--
-<li>The <strong>Components</strong> section describes engineering tools such as directives and services that developers can implement to create the user experience patterns.</li>
--->
-</ul>
-
-<hr>
-
-<p><strong>Next Steps:</strong></p>
-<ul>
-<li><a href="../../components">Components Reference &raquo;</a></li>
-</ul>
-
-<hr>
-
 <p><strong>Coming Soon:</strong></p>
 <ul>
 <li>Layout Elements</li>
 <li>Patterns</li>
 </ul>
-
+-->
 
 <!--
 <hr>

--- a/content/getting-started/start-a-project/index.html
+++ b/content/getting-started/start-a-project/index.html
@@ -1,7 +1,7 @@
 ---
 layout: layout-sidebar
 order: 11
-name: "Start a Project"
+name: Start a project
 showNavDropdown: true
 ---
 
@@ -13,7 +13,7 @@ showNavDropdown: true
 
 <p class="alert alert-info"><strong><em>Prerequisite:</em></strong> Keep in mind that the heart of {{ stache.config.product_name_short }} is <a href="https://angularjs.org/" class="alert-link" target="blank">AngularJS</a> and <a href="http://getbootstrap.com/" class="alert-link" target="blank">Bootstrap</a>, so you need to be familiar with these technologies to build with {{ stache.config.product_name_short }}.</p>
 
-<h2>Create a Page</h2>
+<h2>Create a page</h2>
 
 <p>Let's start with a basic HTML page that includes {{ stache.config.product_name_short }}.</p>
 
@@ -34,9 +34,9 @@ showNavDropdown: true
 <p class="alert alert-info">You can also open the file directly in a browser, but the browser will put restrictions on how JavaScript runs when you do that.</p>
 -->
 
-<h2>Add Content to the Page</h2>
+<h2>Add content to the page</h2>
 
-<h3>Simple HTML Elements</h3>
+<h3>Simple HTML elements</h3>
 
 <p>Let's brighten things up a bit by adding a button to the page. {{ stache.config.product_name_short }} is based on Bootstrap, so we can use all <a href="http://getbootstrap.com/css/" target="blank">standard Bootstrap CSS classes</a>.</p>
 
@@ -55,7 +55,7 @@ showNavDropdown: true
 
 <p>While the button respects the Bootstrap <code>btn-primary</code> class, it looks a little different than the default Bootstrap button.  {{ stache.config.product_name_short }} overrides Bootstrap styles with its own styles to create a unique user interface that still takes advantage of the responsive nature of its Bootstrap core.</p>
 
-<h3>AngularJS Directives</h3>
+<h3>AngularJS directives</h3>
 
 <p>Of course, {{ stache.config.product_name_short }} is more than just CSS. It also features an <a href="../../components">extensive library</a> of <a href="https://angularjs.org/" target="blank">AngularJS</a> components. To use these, your page must define an Angular application.</p>
 
@@ -99,5 +99,5 @@ showNavDropdown: true
 
 <hr>
 
-<p><strong>Next Step:</strong> <a href="../create-a-record-page/">Create a Record Page &raquo;</a></p>
+<p><strong>Next step:</strong> <a href="../create-a-record-page/">Create a record page &raquo;</a></p>
 </div>

--- a/content/index.html
+++ b/content/index.html
@@ -25,12 +25,12 @@ badges:
 
 learn:
   - icon: rocket
-    title: Design Principles
+    title: Design principles
     description: The inspiration for <%= stache.config.product_name_short %> is creating the optimal user experience. Check out the components that implement our design patterns and principles.
     url: /design/patterns
 
   - icon: code
-    title: Developer Tools
+    title: Developer tools
     description: <%= stache.config.product_name_short %> uses Bootstrap, SASS, and AngularJS to provide the building blocks for your applications. Explore these tools in our library of components.
     url: /javascript
 
@@ -63,12 +63,12 @@ why:
   - icon: tree
     animate: fadeInUp
     title: Natural
-    description: The way that users flow through the system should create a sense of confidence in their work.
+    description: The way that users flow through the system creates a sense of confidence in their work.
 
   - icon: wheelchair
     animate: fadeInUp
     title: Accessible
-    description: <%= stache.config.product_name_short %> strives to accommodate users. From the devices people use to their physical capabilities, we care.
+    description: <%= stache.config.product_name_short %> strives to accommodate users. From their devices to their physical capabilities, we care.
 
 slides:
   - img: fenxt.png
@@ -122,9 +122,9 @@ slides:
         <img src="/assets/img/renxt.png" class="img-responsive box-shadow-ui-screenshot" alt="RENXT" />
       </div>
       <div class="col-sm-6 col-sm-offset-1">
-        <h1>Create a Seamless User Interface</h1>
-        <p class="lead">Blackbaud’s next-generation user-experience framework brings a consistent, cohesive experience to Blackbaud’s products, and you can use it to bring that same consistent experience to your customizations and applications.</p>
-        <p class="lead">{{ stache.config.product_name_short }} provides an HTML, CSS, and JavaScript framework to implement Blackbaud’s design patterns, along with the guidance to handle visual design and interaction patterns.</p>
+        <h1>Create a seamless user interface</h1>
+        <p class="lead">Blackbaud’s next-generation user-experience framework brings a consistent, cohesive experience to Blackbaud products, and you can use it to bring that same consistent experience to your customizations and applications.</p>
+        <p class="lead">{{ stache.config.product_name_short }} provides an HTML, CSS, and JavaScript framework to implement Blackbaud’s design patterns, along with the guidance to handle visual design and user interactions.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This set of changes just corrects headline styles to use sentence-style capitalization and updates the Reference materials section of the Getting started content to reflect that the plan for the site hierarchy changed and that the site now includes the Guidelines and Core design sections.
