### PR TITLE
Reword warning to emphasize redirect

### DIFF
--- a/includes/partial-header.html
+++ b/includes/partial-header.html
@@ -16,7 +16,7 @@
   <div class="{{ stache.config.bootstrap_container }}">
     <div class="row">
       <div class="col-sm-12">
-        <strong>Warning:</strong> This site describes <a href="https://angularjs.org/">the AngularJS (1.x) implementation</a> of the SKY UX framework. We still support this version, but it is in maintenance mode. We no longer develop features for this version of SKY UX, and we recommend that you use the latest version instead. For more information, see <a href="https://developer.blackbaud.com/skyux">developer.blackbaud.com/skyux</a>.
+        <strong>Warning:</strong> We no longer develop features for this version of SKY UX, and we recommend that you use the latest version instead. This site describes <a href="https://angularjs.org/">the AngularJS (1.x) implementation</a> of the SKY UX framework. We still support this version, but it is in maintenance mode. For more information, see <a href="https://developer.blackbaud.com/skyux">developer.blackbaud.com/skyux</a>.
       </div>
     </div>
   </div>


### PR DESCRIPTION
Reorganizing warning across the top of the page to put the redirect first after feedback that it was overlooked.